### PR TITLE
Apply style for iOS alert buttons

### DIFF
--- a/saga/alert.js
+++ b/saga/alert.js
@@ -37,6 +37,7 @@ export function * alert(title, message, buttons = [], options ) {
     const _buttons = buttons.map( b => {
         return {
             text: b.text,
+            style: b.style,
             onPress: _createAction(b)
         }
     });


### PR DESCRIPTION
Add support for the below:

**iOS**

On iOS you can specify any number of buttons. Each button can optionally specify a style, which is one of 

> 'default', 'cancel' or 'destructive'.